### PR TITLE
remove `pty.waitFor()` && add session close handle

### DIFF
--- a/src/main/java/com/kodedu/cloudterm/service/TerminalService.java
+++ b/src/main/java/com/kodedu/cloudterm/service/TerminalService.java
@@ -147,7 +147,7 @@ public class TerminalService {
     }
 
     public void onTerminalClose(){
-        if(process.isAlive()){
+        if(null!=process && process.isAlive()){
             process.destroy();
         }
     }

--- a/src/main/java/com/kodedu/cloudterm/service/TerminalService.java
+++ b/src/main/java/com/kodedu/cloudterm/service/TerminalService.java
@@ -44,20 +44,18 @@ public class TerminalService {
     }
 
     public void onTerminalReady() {
-
-        ThreadHelper.start(() -> {
-            isReady = true;
-            try {
-                initializeProcess();
-            } catch (Exception e) {
-                // e.printStackTrace();
-            }
-        });
-
+        try {
+            initializeProcess();
+            isReady =true;
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
     }
 
     private void initializeProcess() throws Exception {
-
+        if(isReady){
+            return;
+        }
         String userHome = System.getProperty("user.home");
         Path dataDir = Paths.get(userHome).resolve(".terminalfx");
         IOHelper.copyLibPty(dataDir);
@@ -91,8 +89,6 @@ public class TerminalService {
         ThreadHelper.start(() -> {
             printReader(errorReader);
         });
-
-        process.waitFor();
 
     }
 

--- a/src/main/java/com/kodedu/cloudterm/service/TerminalService.java
+++ b/src/main/java/com/kodedu/cloudterm/service/TerminalService.java
@@ -43,13 +43,8 @@ public class TerminalService {
 
     }
 
-    public void onTerminalReady() {
-        try {
-            initializeProcess();
-            isReady =true;
-        } catch (Exception exception) {
-            exception.printStackTrace();
-        }
+    public void onTerminalReady() throws Exception {
+        initializeProcess();
     }
 
     private void initializeProcess() throws Exception {
@@ -89,6 +84,7 @@ public class TerminalService {
         ThreadHelper.start(() -> {
             printReader(errorReader);
         });
+        this.isReady = true;
 
     }
 
@@ -147,6 +143,12 @@ public class TerminalService {
                 process.setWinSize(new WinSize(this.columns, this.rows));
             }
 
+        }
+    }
+
+    public void onTerminalClose(){
+        if(process.isAlive()){
+            process.destroy();
         }
     }
 

--- a/src/main/java/com/kodedu/cloudterm/websocket/TerminalSocket.java
+++ b/src/main/java/com/kodedu/cloudterm/websocket/TerminalSocket.java
@@ -73,8 +73,11 @@ public class TerminalSocket extends TextWebSocketHandler {
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        session.close();
-        terminalService.onTerminalClose();
+        try {
+            session.close();
+        }finally {
+            terminalService.onTerminalClose();
+        }
     }
 
     @Override

--- a/src/main/java/com/kodedu/cloudterm/websocket/TerminalSocket.java
+++ b/src/main/java/com/kodedu/cloudterm/websocket/TerminalSocket.java
@@ -73,7 +73,8 @@ public class TerminalSocket extends TextWebSocketHandler {
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        super.afterConnectionClosed(session, status);
+        session.close();
+        terminalService.onTerminalClose();
     }
 
     @Override

--- a/src/main/resources/public/js/main.js
+++ b/src/main/resources/public/js/main.js
@@ -34,7 +34,8 @@ const resizeTerm = (term, ws) => {
 };
 
 $(() => {
-  let ws = new WebSocket('ws://' + location.host + '/terminal');
+  let sec = location.protocol.indexOf("https")>-1
+  let ws = new WebSocket(`${sec?"wss":"ws"}://${location.host}/terminal`);
   let term = new Terminal({
     cursorBlink: true,
   });


### PR DESCRIPTION
1. `pty.waitFor()` just hold process wait util process is terminated,  just like `java.lang.Process`. So it's not unnecessary to use thread keep process wait in web application.  Reference at [https://github.com/JetBrains/pty4j/issues/87#event-3457185561](https://github.com/JetBrains/pty4j/issues/87#event-3457185561)

2.  Add method of `onTerminalClose`  to handle the  WebSocket session which is in not open state and release pty process.